### PR TITLE
Add minimal Live Stream Downloader prototype

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,14 @@
+import os
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+CACHE_DIR = os.path.join(BASE_DIR, 'cache')
+OUTPUT_DIR = os.path.join(BASE_DIR, 'downloads')
+FAVORITES_FILE = os.path.join(BASE_DIR, 'favorites.json')
+
+FFMPEG_PATH = 'ffmpeg'
+YTDLP_PATH = 'yt-dlp'
+
+CHECK_INTERVAL = 60  # seconds
+
+for directory in (CACHE_DIR, OUTPUT_DIR):
+    os.makedirs(directory, exist_ok=True)

--- a/favorites_manager.py
+++ b/favorites_manager.py
@@ -1,0 +1,56 @@
+import json
+import os
+import uuid
+
+from config import FAVORITES_FILE
+
+
+class FavoritesManager:
+    def __init__(self):
+        self.favorites = []
+        self.load()
+
+    def load(self):
+        if os.path.exists(FAVORITES_FILE):
+            try:
+                with open(FAVORITES_FILE, 'r', encoding='utf-8') as f:
+                    self.favorites = json.load(f)
+            except Exception:
+                self.favorites = []
+        else:
+            self.favorites = []
+
+    def save(self):
+        with open(FAVORITES_FILE, 'w', encoding='utf-8') as f:
+            json.dump(self.favorites, f, indent=2, ensure_ascii=False)
+
+    def add_favorite(self, name, url, quality='best', auto_capture=False):
+        fav = {
+            'id': str(uuid.uuid4()),
+            'name': name,
+            'url': url,
+            'quality': quality,
+            'auto_capture': auto_capture,
+            'is_live_detected': False
+        }
+        self.favorites.append(fav)
+        self.save()
+        return fav
+
+    def remove_favorite(self, fav_id):
+        self.favorites = [f for f in self.favorites if f['id'] != fav_id]
+        self.save()
+
+    def update_favorite(self, fav_id, **kwargs):
+        for fav in self.favorites:
+            if fav['id'] == fav_id:
+                fav.update(kwargs)
+                self.save()
+                return fav
+        return None
+
+    def get_favorite(self, fav_id):
+        for fav in self.favorites:
+            if fav['id'] == fav_id:
+                return fav
+        return None

--- a/main_downloader_app.py
+++ b/main_downloader_app.py
@@ -1,0 +1,128 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from favorites_manager import FavoritesManager
+from stream_handler import StreamDownloader
+from stream_checker import StreamChecker
+
+
+class App:
+    def __init__(self, root):
+        self.root = root
+        self.root.title('Live Stream Downloader')
+        self.fav_manager = FavoritesManager()
+        self.downloads = []
+
+        self.create_widgets()
+        self.stream_checker = StreamChecker(self.fav_manager, self.handle_auto_capture, self.log)
+        self.stream_checker.start()
+
+    def create_widgets(self):
+        frm_entry = ttk.Frame(self.root)
+        frm_entry.pack(fill='x', padx=5, pady=5)
+
+        ttk.Label(frm_entry, text='URL:').pack(side='left')
+        self.entry_url = ttk.Entry(frm_entry, width=50)
+        self.entry_url.pack(side='left', padx=5)
+
+        self.combo_quality = ttk.Combobox(frm_entry, values=['best'], width=15)
+        self.combo_quality.set('best')
+        self.combo_quality.pack(side='left', padx=5)
+
+        ttk.Button(frm_entry, text='Obtener Calidades', command=self.get_qualities).pack(side='left', padx=5)
+        ttk.Button(frm_entry, text='Iniciar Descarga', command=self.start_download).pack(side='left', padx=5)
+        ttk.Button(frm_entry, text='Añadir a Favoritos', command=self.add_favorite).pack(side='left', padx=5)
+
+        frm_fav = ttk.Labelframe(self.root, text='Favoritos')
+        frm_fav.pack(fill='both', expand=True, padx=5, pady=5)
+
+        self.list_fav = tk.Listbox(frm_fav, height=6)
+        self.list_fav.pack(side='left', fill='both', expand=True)
+        self.list_fav.bind('<<ListboxSelect>>', self.on_select_favorite)
+
+        fav_buttons = ttk.Frame(frm_fav)
+        fav_buttons.pack(side='left', fill='y')
+        ttk.Button(fav_buttons, text='Iniciar Fav.', command=self.start_selected_favorite).pack(fill='x', pady=2)
+        ttk.Button(fav_buttons, text='Quitar Fav.', command=self.remove_selected_favorite).pack(fill='x', pady=2)
+
+        self.text_log = tk.Text(self.root, height=10)
+        self.text_log.pack(fill='both', expand=True, padx=5, pady=5)
+
+        self.refresh_favorites()
+
+    def log(self, msg):
+        self.text_log.insert('end', msg + '\n')
+        self.text_log.see('end')
+
+    def get_qualities(self):
+        url = self.entry_url.get().strip()
+        if not url:
+            return
+        output = StreamDownloader.get_available_qualities(url)
+        self.log(output)
+
+    def start_download(self):
+        url = self.entry_url.get().strip()
+        if not url:
+            messagebox.showerror('Error', 'Ingrese una URL')
+            return
+        quality = self.combo_quality.get()
+        downloader = StreamDownloader(url, quality, log_callback=self.log)
+        self.downloads.append(downloader)
+        downloader.start()
+        self.log(f'Descarga iniciada: {url}')
+
+    def add_favorite(self):
+        url = self.entry_url.get().strip()
+        if not url:
+            return
+        name = url
+        fav = self.fav_manager.add_favorite(name, url, self.combo_quality.get())
+        self.refresh_favorites()
+        self.log(f'Favorito agregado: {fav["name"]}')
+
+    def refresh_favorites(self):
+        self.list_fav.delete(0, 'end')
+        for fav in self.fav_manager.favorites:
+            self.list_fav.insert('end', fav['name'])
+
+    def on_select_favorite(self, event):
+        if not self.list_fav.curselection():
+            return
+        index = self.list_fav.curselection()[0]
+        fav = self.fav_manager.favorites[index]
+        self.entry_url.delete(0, 'end')
+        self.entry_url.insert(0, fav['url'])
+        self.combo_quality.set(fav.get('quality', 'best'))
+
+    def start_selected_favorite(self):
+        if not self.list_fav.curselection():
+            return
+        index = self.list_fav.curselection()[0]
+        fav = self.fav_manager.favorites[index]
+        downloader = StreamDownloader(fav['url'], fav.get('quality', 'best'), log_callback=self.log)
+        self.downloads.append(downloader)
+        downloader.start()
+        self.log(f'Descarga iniciada: {fav["name"]}')
+
+    def remove_selected_favorite(self):
+        if not self.list_fav.curselection():
+            return
+        index = self.list_fav.curselection()[0]
+        fav = self.fav_manager.favorites[index]
+        self.fav_manager.remove_favorite(fav['id'])
+        self.refresh_favorites()
+        self.log(f'Favorito eliminado: {fav["name"]}')
+
+    def handle_auto_capture(self, fav):
+        downloader = StreamDownloader(fav['url'], fav.get('quality', 'best'), log_callback=self.log)
+        self.downloads.append(downloader)
+        downloader.start()
+        self.log(f'Auto captura iniciada: {fav["name"]}')
+
+
+if __name__ == '__main__':
+    root = tk.Tk()
+    app = App(root)
+    root.protocol('WM_DELETE_WINDOW', root.destroy)
+    root.mainloop()

--- a/stream_checker.py
+++ b/stream_checker.py
@@ -1,0 +1,35 @@
+import threading
+import subprocess
+import time
+
+from config import YTDLP_PATH, CHECK_INTERVAL
+
+
+class StreamChecker(threading.Thread):
+    def __init__(self, favorites_manager, on_live_callback, log_callback=None):
+        super().__init__(daemon=True)
+        self.fav_manager = favorites_manager
+        self.on_live_callback = on_live_callback
+        self.log_callback = log_callback or (lambda msg: None)
+        self._stop_event = threading.Event()
+
+    def run(self):
+        while not self._stop_event.is_set():
+            for fav in self.fav_manager.favorites:
+                if not fav.get('auto_capture'):
+                    continue
+                url = fav['url']
+                cmd = [YTDLP_PATH, '--no-playlist', '--simulate', url]
+                try:
+                    subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+                    self.log_callback(f"Live detected: {fav['name']}")
+                    self.on_live_callback(fav)
+                except subprocess.CalledProcessError:
+                    pass
+            for _ in range(CHECK_INTERVAL):
+                if self._stop_event.is_set():
+                    break
+                time.sleep(1)
+
+    def stop(self):
+        self._stop_event.set()

--- a/stream_handler.py
+++ b/stream_handler.py
@@ -1,0 +1,48 @@
+import os
+import threading
+import subprocess
+import time
+
+from config import OUTPUT_DIR, YTDLP_PATH
+
+
+class StreamDownloader(threading.Thread):
+    def __init__(self, url, quality='best', output_name=None, progress_callback=None, log_callback=None):
+        super().__init__(daemon=True)
+        self.url = url
+        self.quality = quality
+        self.output_name = output_name or f"download_{int(time.time())}.mp4"
+        self.progress_callback = progress_callback or (lambda msg: None)
+        self.log_callback = log_callback or (lambda msg: None)
+        self._stop_event = threading.Event()
+
+    def run(self):
+        output_path = os.path.join(OUTPUT_DIR, self.output_name)
+        cmd = [YTDLP_PATH, '-f', self.quality, '-o', output_path, self.url]
+        self.log_callback(f"Running: {' '.join(cmd)}")
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+        for line in process.stdout:
+            if self._stop_event.is_set():
+                process.terminate()
+                break
+            if self.progress_callback:
+                self.progress_callback(line.strip())
+
+        process.wait()
+        if process.returncode == 0:
+            self.log_callback(f"Download completed: {output_path}")
+        else:
+            self.log_callback(f"Download failed: {self.url}")
+
+    def stop(self):
+        self._stop_event.set()
+
+    @staticmethod
+    def get_available_qualities(url):
+        cmd = [YTDLP_PATH, '-F', url]
+        try:
+            output = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+            return output
+        except subprocess.CalledProcessError as e:
+            return e.output


### PR DESCRIPTION
## Summary
- add configuration module with output directories
- implement a basic favorites manager with JSON persistence
- create a simple `StreamDownloader` wrapper for yt-dlp
- add a thread-based stream checker to auto-start downloads
- build a minimal Tkinter GUI for managing downloads and favorites

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f65c999bc8329a9908d376accc100